### PR TITLE
DB Secrets: Added authenticated URI

### DIFF
--- a/deploy-as-code/helm/charts/cluster-configs/templates/secrets/db-secret.yaml
+++ b/deploy-as-code/helm/charts/cluster-configs/templates/secrets/db-secret.yaml
@@ -9,10 +9,11 @@ metadata:
   namespace: {{ $ns }}
 type: Opaque
 data:
-  username: {{ index $.Values "cluster-configs" "secrets" "db" "username" | b64enc | quote }}
-  password: {{ index $.Values "cluster-configs" "secrets" "db" "password" | b64enc | quote }}
-  pg-username: {{ index $.Values "cluster-configs" "secrets" "db" "pg-username" | b64enc | quote }}
-  pg-password: {{ index $.Values "cluster-configs" "secrets" "db" "pg-password" | b64enc | quote }}
+  mongo-db-username: {{ index $.Values "cluster-configs" "secrets" "db" "mongo-db-username" | b64enc | quote }}
+  mongo-db-password: {{ index $.Values "cluster-configs" "secrets" "db" "mongo-db-password" | b64enc | quote }}
+  mongo-db-authenticated-uri: {{ index $.Values "cluster-configs" "secrets" "db" "mongo-db-authenticated-uri" | b64enc | quote }}
+  username: {{ index $.Values "cluster-configs" "secrets" "db" "pg-username" | b64enc | quote }}
+  password: {{ index $.Values "cluster-configs" "secrets" "db" "pg-password" | b64enc | quote }}
   flyway-username: {{ index $.Values "cluster-configs" "secrets" "db" "flywayUsername" | b64enc | quote }}
   flyway-password: {{ index $.Values "cluster-configs" "secrets" "db" "flywayPassword" | b64enc | quote }}
   druid_metadata_storage_connector_user: {{ index $.Values "cluster-configs" "secrets" "db" "druid_username" | b64enc | quote }}


### PR DESCRIPTION
@nikesh-eGov You will have to make changes to ifix-dev-secrets.yaml. 

For the MongoDB configurations we need to pass an authenticated URI to the service. So I have created a new secret for it. You will have to add "mongo-db-authenticated-uri" key in the "db" section of the ifix-dev-secrets.yaml. 
The value for it will be in the following format
"mongodb://[username]:[password]@[host]:27017/?retryWrites=false"

Also, Please do following renaming in the "db" section: 
1. username to mongo-db-username
2. password to mongo-db-password