### PR TITLE
IFIx-43

### DIFF
--- a/deploy-as-code/helm/charts/municipal-services/ws-services/values.yaml
+++ b/deploy-as-code/helm/charts/municipal-services/ws-services/values.yaml
@@ -90,7 +90,7 @@ env: |
   - name: EGOV_MGRAMSEVA_APPL_DOMAIN
     valueFrom:
       configMapKeyRef:
-        name: egov-service-host
+        name: egov-config
         key: egov-services-fqdn-name
   - name: EGOV_MGRAMSEVA_UI_PATH
     value: mgramseva/login


### PR DESCRIPTION
read egov-services-fqdn-name from egov-config not from egov-serice-host